### PR TITLE
Protocol Field In Domain Parser

### DIFF
--- a/api/exec.go
+++ b/api/exec.go
@@ -35,7 +35,8 @@ func ExecGurl() {
 	err = tcm.InitTCPConn()
 	errutils.CheckErr(err)
 
-	if dp.IsWebSocket {
+	switch dp.Protocol {
+	case domainparser.ProtocolWS:
 		ws.NewWebSocketManager(
 			dp.Domain,
 			dp.Path,
@@ -43,22 +44,22 @@ func ExecGurl() {
 			tcm,
 			cp.Verbose,
 		).Manage()
-		return
+
+	case domainparser.ProtocolHTTP:
+		httpRequest := http.NewHTTPRequestGenerator(
+			dp.Domain,
+			dp.Path,
+			cp.Cookies,
+			method,
+			cp.Data,
+			cp.DataType,
+		).Generate()
+
+		if cp.Verbose {
+			terminalutils.PrintHTTPClientInfo(connInfo.IP.String(), httpRequest)
+		}
+
+		respBytes := tcm.DispatchHTTPRequest(httpRequest)
+		http.NewHTTPResponseParser(respBytes).Parse().Print(cp.Verbose)
 	}
-
-	httpRequest := http.NewHTTPRequestGenerator(
-		dp.Domain,
-		dp.Path,
-		cp.Cookies,
-		method,
-		cp.Data,
-		cp.DataType,
-	).Generate()
-
-	if cp.Verbose {
-		terminalutils.PrintHTTPClientInfo(connInfo.IP.String(), httpRequest)
-	}
-
-	respBytes := tcm.DispatchHTTPRequest(httpRequest)
-	http.NewHTTPResponseParser(respBytes).Parse().Print(cp.Verbose)
 }

--- a/internal/domainparser/domain_parser.go
+++ b/internal/domainparser/domain_parser.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+const (
+	ProtocolHTTP uint8 = iota
+	ProtocolWS
+)
+
 type DomainParser struct {
 	IsLocalHost   bool
 	IsWebSocket   bool

--- a/internal/domainparser/domain_parser.go
+++ b/internal/domainparser/domain_parser.go
@@ -2,17 +2,18 @@ package domainparser
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
 const (
-	ProtocolHTTP uint8 = iota
+	ProtocolHTTP uint8 = iota + 1
 	ProtocolWS
 )
 
 type DomainParser struct {
 	IsLocalHost   bool
-	IsWebSocket   bool
+	Protocol      uint8
 	Domain        string
 	Path          string
 	DomainSegment []string
@@ -70,9 +71,11 @@ func (d *DomainParser) trimProtocolFromWebSocketDomain() error {
 	return errors.New("if websocket, input domain must contain protocol: ws:// or wss://")
 }
 
-func (d *DomainParser) determineIfWebSocket() {
+func (d *DomainParser) determineProtocol() {
 	if strings.HasPrefix(d.Domain, "ws://") || strings.HasPrefix(d.Domain, "wss://") {
-		d.IsWebSocket = true
+		d.Protocol = ProtocolWS
+	} else {
+		d.Protocol = ProtocolHTTP
 	}
 }
 
@@ -84,18 +87,22 @@ func (d *DomainParser) determineIfLocalhost() {
 
 func (d *DomainParser) Parse() error {
 	d.Domain = strings.TrimSpace(d.Domain)
-	d.determineIfWebSocket()
+	d.determineProtocol()
 	d.determineIfLocalhost()
 
-	// WebSocket protocol
-	if d.IsWebSocket {
+	switch d.Protocol {
+	case ProtocolWS:
 		if err := d.trimProtocolFromWebSocketDomain(); err != nil {
 			return err
 		}
-	} else {
+
+	case ProtocolHTTP:
 		if err := d.trimProtocolFromHTTPDomain(); err != nil {
 			return err
 		}
+
+	default:
+		return fmt.Errorf("wrong protocol. must never reach here")
 	}
 
 	d.separateDomainAndPath()


### PR DESCRIPTION
# Overview

This PR enhanced the `DomainParser` struct with `Protocol` field instead of `IsWebsocket`. This makes more sense logically and it enhanced the structure of the code.

- **added protocol constants**
- **modified protocol into its own field**
