### PR TITLE
`conninfo` package unit test

### DIFF
--- a/api/conninfo/conn_info_resolver.go
+++ b/api/conninfo/conn_info_resolver.go
@@ -78,7 +78,6 @@ func (c ConnInfoResolver) fetchCachedIp() (net.IP, uint8, error) {
 func (c ConnInfoResolver) cacheDomainIp(ipStr string) error {
 	domainFile := filepath.Join(c.ipCacheDir, c.domain)
 
-	// TODO: Decide which one to use for writing
 	// Method 1: (commented out for now)
 	// 0o600 read and write permissions only for the owner.
 	//

--- a/api/conninfo/conn_info_test.go
+++ b/api/conninfo/conn_info_test.go
@@ -1,6 +1,8 @@
 package conninfo
 
-import "testing"
+import (
+	"testing"
+)
 
 var testCir = ConnInfoResolver{}
 
@@ -24,6 +26,35 @@ func TestIsDomainLocalhost(t *testing.T) {
 			resp := testCir.isDomainLocalHost()
 			if resp != test.expectedRes {
 				t.Fatalf("expected: %v\tgot:%v", test.expectedRes, resp)
+			}
+		})
+	}
+}
+
+func TestExtractPort(t *testing.T) {
+	tests := []struct {
+		name        string
+		domain      string
+		expectedRes int
+		expectedErr string
+	}{
+		{name: "should_give_correct_port", domain: "127.0.0.1:1111", expectedRes: 1111},
+		{name: "should_give_correct_port", domain: "127.0.0.1:9999", expectedRes: 9999},
+		{name: "should_give_correct_port", domain: "127.0.0.1", expectedRes: 0, expectedErr: "domain must be in format of ip:port"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testCir.domain = test.domain
+
+			res, err := testCir.extractPort()
+
+			if test.expectedRes != res {
+				t.Fatalf("expected result: %d\tgot: %d", test.expectedRes, res)
+			}
+
+			if err != nil && test.expectedErr != err.Error() {
+				t.Fatalf("expected err: %s\tgot: %s", test.expectedErr, err.Error())
 			}
 		})
 	}

--- a/api/conninfo/conn_info_test.go
+++ b/api/conninfo/conn_info_test.go
@@ -1,0 +1,30 @@
+package conninfo
+
+import "testing"
+
+var testCir = ConnInfoResolver{}
+
+func TestIsDomainLocalhost(t *testing.T) {
+	tests := []struct {
+		name        string
+		domain      string
+		expectedRes bool
+	}{
+		{name: "should_give_true_with_localhost_ip", domain: "127.0.0.1", expectedRes: true},
+		{name: "should_give_true_with_localhost_ip", domain: "127.0.0.1:1111", expectedRes: true},
+		{name: "should_give_true_with_localhost_string", domain: "localhost", expectedRes: true},
+		{name: "should_give_true_with_localhost_string", domain: "localhost:9999", expectedRes: true},
+		{name: "should_give_false_with_invalid_string", domain: "google.com", expectedRes: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testCir.domain = test.domain
+
+			resp := testCir.isDomainLocalHost()
+			if resp != test.expectedRes {
+				t.Fatalf("expected: %v\tgot:%v", test.expectedRes, resp)
+			}
+		})
+	}
+}

--- a/api/conninfo/conn_info_test.go
+++ b/api/conninfo/conn_info_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/saeidalz13/gurl/api/dns"
 )
 
 var testCir = ConnInfoResolver{}
@@ -94,11 +96,23 @@ func TestCacheIP(t *testing.T) {
 		t.Fatalf("expected saved IP: %s\tgot: %s", ipToSave, string(savedIp))
 	}
 
+	// Testing fetching the cached file
+	ip, ipType, err := testCir.fetchCachedIp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ip.String() != ipToSave {
+		t.Fatalf("expected ip: %s\tgot from reading cached: %s", ipToSave, ip.String())
+	}
+	if ipType != dns.IpTypeV4 {
+		t.Fatalf("expected ip type: %d\tgot: %d", dns.IpTypeV4, ipType)
+	}
+
+	// Clean up test files of cache
 	err = os.Remove(domainFile)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	err = os.Remove(ipCacheDir)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/domainparser/domain_parser.go
+++ b/internal/domainparser/domain_parser.go
@@ -109,6 +109,7 @@ func (d *DomainParser) Parse() error {
 	}
 
 	d.separateDomainAndPath()
+	d.Domain = strings.ToLower(d.Domain)
 	d.splitDomainIntoSegments()
 	return nil
 }


### PR DESCRIPTION
# Overview

This PR added unit tests to `conninfo` package.

- **modified domain parser to lower the domain; added check for localhost domain test for conn info resolver**
- **added localhost domain test for conn info resolver**
- **added extract port unit test**
- **added unit test for caching IP**
- **added unit test for  method**
